### PR TITLE
feat: Nocturne public story reading (Plan 3)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,71 @@
 @import "tailwindcss";
+@config "../../tailwind.config.ts";
 
 :root {
-  --font-serif: "Georgia", serif;
-  --font-sans: system-ui, sans-serif;
-  --font-mono: ui-monospace, monospace;
+  --font-serif: "Bodoni Moda", Georgia, serif;
+  --font-sans: "Space Grotesk", system-ui, sans-serif;
+  --font-mono: ui-monospace, "SFMono-Regular", Menlo, monospace;
 }
 
 body {
-  background-color: #141418;
-  color: #ECECEF;
+  background-color: #0e0e10;
+  color: #ececef;
   font-family: var(--font-sans);
+  line-height: 1.6;
+}
+
+a {
+  color: #ca6e6a;
+  text-decoration: none;
+}
+
+/* Rendered story HTML (already sanitized during ETL). */
+.prose {
+  font-size: 18px;
+  line-height: 1.85;
+  color: rgba(236, 236, 239, 0.82);
+  max-width: 64ch;
+}
+.prose p {
+  margin: 0 0 1.4em;
+}
+.prose h2,
+.prose h3 {
+  font-family: var(--font-serif);
+  color: #ececef;
+  line-height: 1.15;
+  margin: 1.8em 0 0.6em;
+}
+.prose h2 {
+  font-size: 28px;
+}
+.prose h3 {
+  font-size: 22px;
+}
+.prose a {
+  color: #ca6e6a;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 12px;
+  margin: 1.5em 0;
+}
+.prose blockquote {
+  border-left: 2px solid #b85450;
+  background: rgba(184, 84, 80, 0.06);
+  border-radius: 0 12px 12px 0;
+  margin: 1.5em 0;
+  padding: 0.8em 1.2em;
+  color: rgba(236, 236, 239, 0.82);
+}
+.prose ul,
+.prose ol {
+  margin: 0 0 1.4em;
+  padding-left: 1.4em;
+}
+.prose li {
+  margin: 0.4em 0;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,31 @@
 import "./globals.css";
 import type { ReactNode } from "react";
+import { Bodoni_Moda, Space_Grotesk } from "next/font/google";
+
+const serif = Bodoni_Moda({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  style: ["normal", "italic"],
+  variable: "--font-serif",
+  display: "swap",
+});
+
+const sans = Space_Grotesk({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-sans",
+  display: "swap",
+});
 
 export const metadata = {
-  title: "Nocturne — Internet Horror Archive",
+  title: "Nocturne — Архив интернет-хоррора",
+  description: "Архив интернет-хоррора: истории, сущности и городские легенды сети.",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ru">
-      <body>{children}</body>
+    <html lang="ru" className={`${serif.variable} ${sans.variable}`}>
+      <body className="bg-bg font-sans text-ink antialiased">{children}</body>
     </html>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
+import { copy } from "@/lib/ui-copy";
+
+export default function NotFound() {
+  return (
+    <>
+      <SiteHeader />
+      <main className="mx-auto flex min-h-[70vh] max-w-shell flex-col items-center justify-center px-6 text-center">
+        <h1 className="font-serif text-[clamp(32px,6vw,64px)] font-medium text-ink">
+          {copy.notFound.heading}
+        </h1>
+        <p className="mt-4 max-w-[46ch] text-tx2">{copy.notFound.body}</p>
+        <Link
+          href="/"
+          className="mt-8 rounded-[11px] border border-line bg-s1 px-5 py-3 text-[13px] text-tx2 hover:text-ink"
+        >
+          {copy.notFound.back}
+        </Link>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,77 @@
-export default function HomePage() {
-  return <main>Nocturne</main>;
+import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
+import StoryFeed from "@/components/StoryFeed";
+import ScoreBadge from "@/components/ScoreBadge";
+import { getFeaturedStory, type StorySort } from "@/lib/stories";
+import { excerpt, ratingLabel } from "@/lib/story-display";
+import { storyScore10 } from "@/lib/scoring/display";
+import { copy } from "@/lib/ui-copy";
+
+export const revalidate = 3600;
+
+function parseSort(v: string | undefined): StorySort {
+  return v === "newest" ? "newest" : "popular";
+}
+
+function parseTake(v: string | undefined): number {
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 9 && n <= 90 ? Math.floor(n) : 9;
+}
+
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sort?: string; tag?: string; take?: string }>;
+}) {
+  const sp = await searchParams;
+  const sort = parseSort(sp.sort);
+  const take = parseTake(sp.take);
+  const tagSlug = sp.tag || undefined;
+  const featured = await getFeaturedStory();
+
+  return (
+    <>
+      <SiteHeader />
+      <main className="pt-16">
+        {featured && (
+          <section className="relative mx-auto flex min-h-[80vh] max-w-shell flex-col justify-end px-6 pb-16 pt-24 md:px-10">
+            <div className="flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.2em]">
+              <span className="h-1.5 w-1.5 rounded-full bg-crimson-2" />
+              <span className="text-crimson-2">{copy.hero.featured}</span>
+              {featured.tags[0] && (
+                <>
+                  <span className="text-tx3">·</span>
+                  <span className="text-tx3">{featured.tags[0].name}</span>
+                </>
+              )}
+            </div>
+            <h1 className="mt-6 max-w-[16ch] font-serif text-[clamp(48px,9vw,120px)] font-medium leading-[0.92] text-ink">
+              {featured.title}
+            </h1>
+            <p className="mt-6 max-w-[40ch] font-serif text-[clamp(18px,2.2vw,26px)] italic text-tx2">
+              {excerpt(featured.intro, featured.contentHtml, 200)}
+            </p>
+            <div className="mt-8 flex flex-wrap items-center gap-8">
+              <Link
+                href={`/story/${featured.slug}`}
+                className="rounded-[11px] border border-crimson bg-gradient-to-b from-crimson-2 to-crimson-deep px-5 py-3 text-[14px] font-medium text-white"
+              >
+                {copy.hero.read}
+              </Link>
+              <div className="flex flex-col">
+                <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-tx3">
+                  {ratingLabel(storyScore10(featured.score))}
+                </span>
+                <ScoreBadge score={featured.score} size="lg" />
+              </div>
+            </div>
+          </section>
+        )}
+
+        <StoryFeed sort={sort} tagSlug={tagSlug} take={take} />
+      </main>
+      <SiteFooter />
+    </>
+  );
 }

--- a/src/app/story/[slug]/page.tsx
+++ b/src/app/story/[slug]/page.tsx
@@ -1,0 +1,150 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
+import ScoreBadge from "@/components/ScoreBadge";
+import ReadingProgress from "@/components/ReadingProgress";
+import StoryCard from "@/components/StoryCard";
+import {
+  getStoryBySlug,
+  getRelatedStories,
+  getAllApprovedSlugs,
+} from "@/lib/stories";
+import {
+  formatStoryDate,
+  readingTimeMinutes,
+  ratingLabel,
+  excerpt,
+} from "@/lib/story-display";
+import { storyScore10 } from "@/lib/scoring/display";
+import { copy } from "@/lib/ui-copy";
+
+export const revalidate = 3600;
+export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const slugs = await getAllApprovedSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const story = await getStoryBySlug(slug);
+  if (!story) return { title: copy.notFound.heading };
+  const description = excerpt(story.intro, story.contentHtml, 200);
+  return {
+    title: `${story.title} — Kripipasta`,
+    description,
+    openGraph: { title: story.title, description, type: "article" },
+  };
+}
+
+export default async function StoryPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const story = await getStoryBySlug(slug);
+  if (!story) notFound();
+
+  const related = await getRelatedStories(story, 3);
+  const minutes = readingTimeMinutes(story.contentHtml);
+  const posted = formatStoryDate(story.approvedAt ?? story.createdAt);
+  const votes = story.likeCount + story.dislikeCount;
+
+  return (
+    <>
+      <ReadingProgress />
+      <SiteHeader />
+      <main className="pt-16">
+        <article className="mx-auto max-w-shell px-6 md:px-10">
+          <div className="pt-10">
+            <Link href="/" className="font-mono text-[11px] text-tx3 hover:text-ink">
+              {copy.story.backToArchive}
+            </Link>
+          </div>
+
+          <header className="max-w-prose py-10">
+            <div className="flex flex-wrap items-center gap-3 font-mono text-[11px] uppercase tracking-[0.2em]">
+              {story.tags[0] && (
+                <span className="text-crimson-2">{story.tags[0].name}</span>
+              )}
+            </div>
+            <h1 className="mt-5 font-serif text-[clamp(40px,7vw,96px)] font-medium leading-[0.95] text-ink">
+              {story.title}
+            </h1>
+            {story.intro && (
+              <p className="mt-6 font-serif text-[clamp(18px,2.2vw,26px)] italic text-tx2">
+                {story.intro}
+              </p>
+            )}
+            <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 text-[12px] text-tx3">
+              {story.authorName && (
+                <span>
+                  {copy.story.by}{" "}
+                  {story.authorLink ? (
+                    <a href={story.authorLink} className="text-crimson-2">
+                      {story.authorName}
+                    </a>
+                  ) : (
+                    <span className="text-crimson-2">{story.authorName}</span>
+                  )}
+                </span>
+              )}
+              <span>
+                {copy.story.posted} {posted} · {minutes} {copy.story.minRead}
+              </span>
+            </div>
+          </header>
+
+          <div className="grid gap-11 lg:grid-cols-[minmax(0,1fr)_288px]">
+            <div>
+              <div
+                className="prose"
+                dangerouslySetInnerHTML={{ __html: story.contentHtml }}
+              />
+
+              <section className="mt-14 max-w-prose rounded-[16px] border border-line bg-s1 p-7">
+                <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-tx3">
+                  {copy.story.ratingLabel}
+                </p>
+                <div className="mt-4 flex items-end justify-between gap-6">
+                  <ScoreBadge score={story.score} size="lg" />
+                  <span className="font-serif text-[19px] text-tx2">
+                    {ratingLabel(storyScore10(story.score))}
+                  </span>
+                </div>
+                <p className="mt-4 font-mono text-[11.5px] text-tx3">
+                  {copy.story.votesTemplate.replace(
+                    "{count}",
+                    votes.toLocaleString("ru-RU"),
+                  )}
+                </p>
+              </section>
+            </div>
+
+            {related.length > 0 && (
+              <aside className="lg:sticky lg:top-24 lg:self-start">
+                <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.2em] text-tx3">
+                  {copy.story.related}
+                </p>
+                <div className="flex flex-col gap-4">
+                  {related.map((r) => (
+                    <StoryCard key={r.id} story={r} />
+                  ))}
+                </div>
+              </aside>
+            )}
+          </div>
+        </article>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/components/ReadingProgress.tsx
+++ b/src/components/ReadingProgress.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ReadingProgress() {
+  const [pct, setPct] = useState(0);
+
+  useEffect(() => {
+    function onScroll() {
+      const doc = document.documentElement;
+      const max = doc.scrollHeight - doc.clientHeight;
+      setPct(max > 0 ? Math.min(100, (doc.scrollTop / max) * 100) : 0);
+    }
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-x-0 top-0 z-[120] h-[3px] bg-transparent">
+      <div
+        className="h-full bg-gradient-to-r from-crimson-deep to-crimson shadow-[0_0_10px_var(--tw-shadow-color)] shadow-crimson/60 transition-[width] duration-75"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/src/components/ScoreBadge.tsx
+++ b/src/components/ScoreBadge.tsx
@@ -1,0 +1,22 @@
+import { storyScore10 } from "@/lib/scoring/display";
+
+export default function ScoreBadge({
+  score,
+  size = "sm",
+}: {
+  score: number;
+  size?: "sm" | "lg";
+}) {
+  const value = storyScore10(score).toFixed(2);
+  const big = size === "lg";
+  return (
+    <span className="inline-flex items-baseline gap-1 font-serif text-crimson-2">
+      <span className={big ? "text-[56px] leading-none" : "text-[20px]"}>
+        {value}
+      </span>
+      <span className={big ? "text-[19px] text-tx3" : "text-[12px] text-tx3"}>
+        / 10
+      </span>
+    </span>
+  );
+}

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { copy } from "@/lib/ui-copy";
+
+export default function SiteFooter() {
+  return (
+    <footer className="mx-auto max-w-shell px-6 py-16 md:px-10">
+      <div className="grid gap-10 border-t border-line pt-12 md:grid-cols-[1.4fr_1fr_1fr]">
+        <div>
+          <div className="mb-4 flex items-center gap-3">
+            <span className="block h-[10px] w-[10px] rotate-45 bg-crimson" />
+            <span className="font-serif text-[20px] text-ink">
+              {copy.footer.aboutHeading}
+            </span>
+          </div>
+          <p className="max-w-[38ch] text-[13.5px] leading-relaxed text-tx2">
+            {copy.footer.about}
+          </p>
+        </div>
+
+        <div>
+          <h3 className="mb-4 font-mono text-[10px] uppercase tracking-[0.2em] text-tx3">
+            {copy.footer.exploreHeading}
+          </h3>
+          <ul className="space-y-2 text-[13.5px] text-tx2">
+            <li><Link href="/#feed" className="hover:text-ink">{copy.footer.explore.all}</Link></li>
+            <li><Link href="/#feed" className="hover:text-ink">{copy.footer.explore.categories}</Link></li>
+            <li><Link href="/#feed" className="hover:text-ink">{copy.footer.explore.trending}</Link></li>
+            <li><Link href="/#feed" className="hover:text-ink">{copy.footer.explore.index}</Link></li>
+          </ul>
+        </div>
+
+        <div>
+          <h3 className="mb-4 font-mono text-[10px] uppercase tracking-[0.2em] text-tx3">
+            {copy.footer.communityHeading}
+          </h3>
+          <ul className="space-y-2 text-[13.5px] text-tx2">
+            <li><Link href="/#feed" className="hover:text-ink">{copy.footer.community.contribute}</Link></li>
+            <li><Link href="/#feed" className="hover:text-ink">{copy.footer.community.guidelines}</Link></li>
+            <li><Link href="/#feed" className="hover:text-ink">{copy.footer.community.recent}</Link></li>
+          </ul>
+        </div>
+      </div>
+
+      <div className="mt-10 flex flex-wrap justify-between gap-3 border-t border-line pt-6 font-mono text-[9.5px] uppercase tracking-[0.15em] text-tx3">
+        <span>{copy.footer.estLeft}</span>
+        <span>{copy.footer.estRight}</span>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { copy } from "@/lib/ui-copy";
+
+export default function SiteHeader() {
+  return (
+    <header className="fixed inset-x-0 top-0 z-[110] border-b border-line bg-bg/70 backdrop-blur-md">
+      <div className="mx-auto flex max-w-shell items-center gap-6 px-6 py-4 md:px-10">
+        <Link href="/" className="flex items-center gap-3 shrink-0">
+          <span className="block h-[11px] w-[11px] rotate-45 bg-crimson shadow-[0_0_12px_var(--tw-shadow-color)] shadow-crimson/50" />
+          <span className="leading-tight">
+            <span className="block font-serif text-[19px] font-semibold tracking-[0.02em] text-ink">
+              {copy.site.name}
+            </span>
+            <span className="block font-mono text-[8px] uppercase tracking-[0.28em] text-tx3">
+              {copy.site.tagline}
+            </span>
+          </span>
+        </Link>
+
+        <nav className="hidden items-center gap-5 text-[13px] text-tx2 lg:flex">
+          <Link href="/" className="hover:text-ink">{copy.nav.browse}</Link>
+          <Link href="/#feed" className="hover:text-ink">{copy.nav.categories}</Link>
+          <Link href="/#feed" className="hover:text-ink">{copy.nav.trending}</Link>
+          <Link href="/#feed" className="hover:text-ink">{copy.nav.index}</Link>
+        </nav>
+
+        <div className="ml-auto hidden min-w-0 flex-1 items-center md:flex md:max-w-[420px]">
+          <div className="flex w-full items-center gap-2 rounded-[11px] border border-line bg-s1 px-3 py-[9px] text-tx3">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+              <path d="m20 20-3.5-3.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+            <span className="truncate text-[12px]">{copy.header.searchPlaceholder}</span>
+          </div>
+        </div>
+
+        <div className="ml-auto flex items-center gap-3 md:ml-0">
+          <div className="hidden items-center rounded-[10px] border border-line bg-s1 text-[12px] sm:flex">
+            <span className="rounded-[8px] bg-s3 px-2.5 py-1 text-ink">RU</span>
+            <span className="px-2.5 py-1 text-tx3">EN</span>
+          </div>
+          <Link
+            href="/#feed"
+            className="rounded-[11px] border border-crimson bg-gradient-to-b from-crimson-2 to-crimson-deep px-3.5 py-2 text-[13px] font-medium text-white"
+          >
+            {copy.header.submit}
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import type { StoryListItem } from "@/lib/stories";
+import { excerpt } from "@/lib/story-display";
+import ScoreBadge from "@/components/ScoreBadge";
+
+export default function StoryCard({ story }: { story: StoryListItem }) {
+  const primaryTag = story.tags[0];
+  const year = (story.approvedAt ?? story.createdAt).getFullYear();
+  return (
+    <Link
+      href={`/story/${story.slug}`}
+      className="group flex flex-col justify-between rounded-[16px] border border-line bg-s1 p-5 transition hover:-translate-y-1 hover:border-line2 hover:bg-s2"
+    >
+      <div className="flex items-start justify-between gap-3">
+        {primaryTag ? (
+          <span className="rounded-full border border-crimson-deep bg-crimson/10 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.1em] text-crimson-2">
+            {primaryTag.name}
+          </span>
+        ) : (
+          <span />
+        )}
+        <ScoreBadge score={story.score} />
+      </div>
+
+      <div className="mt-8">
+        <h3 className="font-serif text-[26px] font-medium leading-[1.05] text-ink">
+          {story.title}
+        </h3>
+        <p className="mt-3 text-[12.5px] leading-relaxed text-tx2">
+          {excerpt(story.intro, story.contentHtml, 140)}
+        </p>
+      </div>
+
+      <div className="mt-5 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.1em] text-tx3">
+        <span>{year}</span>
+        <span>{story.viewCount.toLocaleString("ru-RU")} просмотров</span>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/StoryFeed.tsx
+++ b/src/components/StoryFeed.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import {
+  getApprovedStories,
+  getFilterTags,
+  type StorySort,
+} from "@/lib/stories";
+import StoryCard from "@/components/StoryCard";
+import { copy } from "@/lib/ui-copy";
+
+const PAGE = 9;
+
+function href(params: { sort: StorySort; tag?: string; take?: number }) {
+  const sp = new URLSearchParams();
+  if (params.sort !== "popular") sp.set("sort", params.sort);
+  if (params.tag) sp.set("tag", params.tag);
+  if (params.take && params.take !== PAGE) sp.set("take", String(params.take));
+  const qs = sp.toString();
+  return `/${qs ? `?${qs}` : ""}#feed`;
+}
+
+export default async function StoryFeed({
+  sort,
+  tagSlug,
+  take,
+}: {
+  sort: StorySort;
+  tagSlug?: string;
+  take: number;
+}) {
+  const [{ items, total }, tags] = await Promise.all([
+    getApprovedStories({ sort, tagSlug, take }),
+    getFilterTags(7),
+  ]);
+
+  const sorts: { key: StorySort; label: string }[] = [
+    { key: "popular", label: copy.feed.sortPopular },
+    { key: "newest", label: copy.feed.sortNewest },
+  ];
+
+  return (
+    <section id="feed" className="mx-auto max-w-shell scroll-mt-24 px-6 py-16 md:px-10">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-crimson-2">
+            {copy.feed.eyebrow}
+          </p>
+          <h2 className="mt-2 font-serif text-[clamp(34px,4vw,52px)] font-medium text-ink">
+            {copy.feed.heading}
+          </h2>
+        </div>
+        <p className="font-mono text-[11px] text-tx3">
+          {copy.feed.countTemplate
+            .replace("{shown}", String(items.length))
+            .replace("{total}", String(total))}
+        </p>
+      </div>
+
+      <div className="mt-8 flex flex-wrap items-center justify-between gap-4">
+        <div className="flex flex-wrap gap-2">
+          <Chip href={href({ sort })} active={!tagSlug} label={copy.feed.allTag} />
+          {tags.map((t) => (
+            <Chip
+              key={t.slug}
+              href={href({ sort, tag: t.slug })}
+              active={tagSlug === t.slug}
+              label={t.name}
+            />
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-tx3">
+            {copy.feed.sortLabel}
+          </span>
+          <div className="flex rounded-[10px] border border-line bg-s1 text-[12px]">
+            {sorts.map((s) => (
+              <Link
+                key={s.key}
+                href={href({ sort: s.key, tag: tagSlug })}
+                className={
+                  s.key === sort
+                    ? "rounded-[8px] bg-s3 px-3 py-1.5 text-ink"
+                    : "px-3 py-1.5 text-tx3 hover:text-ink"
+                }
+              >
+                {s.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="mt-12 text-tx2">{copy.feed.empty}</p>
+      ) : (
+        <div className="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((story) => (
+            <StoryCard key={story.id} story={story} />
+          ))}
+        </div>
+      )}
+
+      {items.length < total && (
+        <div className="mt-10 flex justify-center">
+          <Link
+            href={href({ sort, tag: tagSlug, take: take + PAGE })}
+            className="rounded-[12px] border border-line bg-s1 px-6 py-3 text-[13px] text-tx2 hover:border-line2 hover:text-ink"
+          >
+            {copy.feed.loadMore}
+          </Link>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Chip({
+  href,
+  active,
+  label,
+}: {
+  href: string;
+  active: boolean;
+  label: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className={
+        active
+          ? "rounded-full border border-crimson-deep bg-crimson/10 px-3.5 py-1.5 text-[12px] text-crimson-2"
+          : "rounded-full border border-line bg-s1 px-3.5 py-1.5 text-[12px] text-tx2 hover:text-ink"
+      }
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -1,0 +1,148 @@
+import { prisma } from "@/lib/db";
+import type { Prisma } from "@prisma/client";
+
+export type StorySort = "popular" | "newest";
+
+export interface StoryListItem {
+  id: string;
+  slug: string;
+  title: string;
+  intro: string;
+  contentHtml: string;
+  score: number;
+  viewCount: number;
+  likeCount: number;
+  dislikeCount: number;
+  createdAt: Date;
+  approvedAt: Date | null;
+  tags: { slug: string; name: string }[];
+}
+
+export interface StoryDetail extends StoryListItem {
+  language: string;
+  authorName: string;
+  authorLink: string;
+}
+
+export interface StoryListResult {
+  items: StoryListItem[];
+  total: number;
+}
+
+const listSelect = {
+  id: true,
+  slug: true,
+  title: true,
+  intro: true,
+  contentHtml: true,
+  score: true,
+  viewCount: true,
+  likeCount: true,
+  dislikeCount: true,
+  createdAt: true,
+  approvedAt: true,
+  tags: { select: { tag: { select: { slug: true, name: true } } } },
+} satisfies Prisma.StorySelect;
+
+const detailSelect = {
+  ...listSelect,
+  language: true,
+  authorName: true,
+  authorLink: true,
+} satisfies Prisma.StorySelect;
+
+type ListRow = Prisma.StoryGetPayload<{ select: typeof listSelect }>;
+type DetailRow = Prisma.StoryGetPayload<{ select: typeof detailSelect }>;
+
+function toListItem(row: ListRow): StoryListItem {
+  const { tags, ...rest } = row;
+  return { ...rest, tags: tags.map((t) => t.tag) };
+}
+
+function toDetail(row: DetailRow): StoryDetail {
+  const { tags, ...rest } = row;
+  return { ...rest, tags: tags.map((t) => t.tag) };
+}
+
+const orderBy: Record<StorySort, Prisma.StoryOrderByWithRelationInput[]> = {
+  popular: [{ score: "desc" }, { createdAt: "desc" }],
+  newest: [{ approvedAt: "desc" }, { createdAt: "desc" }],
+};
+
+export async function getApprovedStories(opts: {
+  sort?: StorySort;
+  tagSlug?: string;
+  skip?: number;
+  take?: number;
+}): Promise<StoryListResult> {
+  const { sort = "popular", tagSlug, skip = 0, take = 9 } = opts;
+  const where: Prisma.StoryWhereInput = {
+    status: "APPROVED",
+    ...(tagSlug ? { tags: { some: { tag: { slug: tagSlug } } } } : {}),
+  };
+  const [rows, total] = await Promise.all([
+    prisma.story.findMany({
+      where,
+      select: listSelect,
+      orderBy: orderBy[sort],
+      skip,
+      take,
+    }),
+    prisma.story.count({ where }),
+  ]);
+  return { items: rows.map(toListItem), total };
+}
+
+export async function getFeaturedStory(): Promise<StoryDetail | null> {
+  const row = await prisma.story.findFirst({
+    where: { status: "APPROVED" },
+    select: detailSelect,
+    orderBy: [{ score: "desc" }, { createdAt: "desc" }],
+  });
+  return row ? toDetail(row) : null;
+}
+
+export async function getStoryBySlug(slug: string): Promise<StoryDetail | null> {
+  const row = await prisma.story.findFirst({
+    where: { slug, status: "APPROVED" },
+    select: detailSelect,
+  });
+  return row ? toDetail(row) : null;
+}
+
+export async function getRelatedStories(
+  story: Pick<StoryDetail, "id" | "tags">,
+  take = 3,
+): Promise<StoryListItem[]> {
+  const tagSlugs = story.tags.map((t) => t.slug);
+  if (tagSlugs.length === 0) return [];
+  const rows = await prisma.story.findMany({
+    where: {
+      status: "APPROVED",
+      id: { not: story.id },
+      tags: { some: { tag: { slug: { in: tagSlugs } } } },
+    },
+    select: listSelect,
+    orderBy: [{ score: "desc" }, { createdAt: "desc" }],
+    take,
+  });
+  return rows.map(toListItem);
+}
+
+export async function getAllApprovedSlugs(): Promise<string[]> {
+  const rows = await prisma.story.findMany({
+    where: { status: "APPROVED" },
+    select: { slug: true },
+  });
+  return rows.map((r) => r.slug);
+}
+
+export async function getFilterTags(
+  take = 8,
+): Promise<{ slug: string; name: string }[]> {
+  return prisma.tag.findMany({
+    orderBy: { frequency: "desc" },
+    take,
+    select: { slug: true, name: true },
+  });
+}

--- a/src/lib/story-display.test.ts
+++ b/src/lib/story-display.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripHtml,
+  excerpt,
+  readingTimeMinutes,
+  formatStoryDate,
+  ratingLabel,
+} from "./story-display";
+
+describe("stripHtml", () => {
+  it("removes tags and collapses whitespace", () => {
+    expect(stripHtml("<p>Hello   <b>world</b></p>\n<p>again</p>")).toBe(
+      "Hello world again",
+    );
+  });
+
+  it("decodes nothing and returns empty for empty input", () => {
+    expect(stripHtml("")).toBe("");
+  });
+});
+
+describe("excerpt", () => {
+  it("prefers a non-empty intro verbatim when short enough", () => {
+    expect(excerpt("Короткое интро.", "<p>тело</p>")).toBe("Короткое интро.");
+  });
+
+  it("falls back to stripped content when intro is empty", () => {
+    expect(excerpt("", "<p>Тело истории здесь.</p>")).toBe(
+      "Тело истории здесь.",
+    );
+  });
+
+  it("truncates long text on a word boundary with an ellipsis", () => {
+    const long = "one two three four five six seven eight nine ten";
+    const out = excerpt("", `<p>${long}</p>`, 20);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(21);
+    expect(out).not.toContain("  ");
+  });
+});
+
+describe("readingTimeMinutes", () => {
+  it("returns at least 1 minute for short content", () => {
+    expect(readingTimeMinutes("<p>one two three</p>")).toBe(1);
+  });
+
+  it("rounds up based on 200 wpm", () => {
+    const words = Array.from({ length: 450 }, () => "слово").join(" ");
+    expect(readingTimeMinutes(`<p>${words}</p>`)).toBe(3);
+  });
+});
+
+describe("formatStoryDate", () => {
+  it("formats a date in Russian long form", () => {
+    // 2026-03-03T12:00:00Z
+    expect(formatStoryDate(new Date(Date.UTC(2026, 2, 3, 12)))).toBe(
+      "3 марта 2026 г.",
+    );
+  });
+});
+
+describe("ratingLabel", () => {
+  it("labels high scores positively", () => {
+    expect(ratingLabel(8.5)).toBe("Стоит прочесть");
+  });
+
+  it("labels mid scores neutrally", () => {
+    expect(ratingLabel(6)).toBe("Неоднозначно");
+  });
+
+  it("labels low scores negatively", () => {
+    expect(ratingLabel(3)).toBe("На любителя");
+  });
+});

--- a/src/lib/story-display.ts
+++ b/src/lib/story-display.ts
@@ -1,0 +1,47 @@
+/** Strip HTML tags, decode nothing, collapse all whitespace to single spaces. */
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * A short teaser. Prefers `intro`; otherwise strips `contentHtml`.
+ * Truncates on a word boundary and appends an ellipsis when over `maxChars`.
+ */
+export function excerpt(
+  intro: string,
+  contentHtml: string,
+  maxChars = 160,
+): string {
+  const source = intro.trim() || stripHtml(contentHtml);
+  if (source.length <= maxChars) return source;
+  const clipped = source.slice(0, maxChars);
+  const lastSpace = clipped.lastIndexOf(" ");
+  const base = lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped;
+  return `${base.trimEnd()}…`;
+}
+
+/** Estimated reading time in whole minutes at 200 wpm, minimum 1. */
+export function readingTimeMinutes(contentHtml: string): number {
+  const text = stripHtml(contentHtml);
+  const words = text ? text.split(/\s+/).length : 0;
+  return Math.max(1, Math.ceil(words / 200));
+}
+
+/** Long-form date, Russian by default (e.g. "3 марта 2026 г."). */
+export function formatStoryDate(date: Date, locale = "ru-RU"): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
+/** Qualitative RU label derived from a 0–10 score. */
+export function ratingLabel(score10: number): string {
+  if (score10 >= 7.5) return "Стоит прочесть";
+  if (score10 >= 5) return "Неоднозначно";
+  return "На любителя";
+}

--- a/src/lib/ui-copy.ts
+++ b/src/lib/ui-copy.ts
@@ -1,0 +1,70 @@
+/**
+ * Centralized Russian UI chrome copy. Single source of truth for Plan 3.
+ * Plan 7 (i18n) replaces this with next-intl message catalogs of the same shape.
+ */
+export const copy = {
+  site: {
+    name: "KRIPIPASTA",
+    tagline: "Архив интернет-хоррора",
+  },
+  nav: {
+    browse: "Обзор",
+    categories: "Категории",
+    trending: "Популярное",
+    index: "Указатель",
+  },
+  header: {
+    searchPlaceholder: "Поиск по архиву — истории, категории, эпохи",
+    submit: "Добавить запись",
+  },
+  feed: {
+    eyebrow: "Архив",
+    heading: "Все истории",
+    countTemplate: "Показано {shown} из {total}",
+    sortLabel: "Сортировка",
+    sortPopular: "Популярные",
+    sortNewest: "Новые",
+    allTag: "Все",
+    loadMore: "Показать ещё",
+    empty: "Пока нет опубликованных историй.",
+  },
+  hero: {
+    featured: "История недели",
+    read: "Читать историю →",
+  },
+  story: {
+    backToArchive: "‹ Назад в архив",
+    ratingLabel: "Рейтинг сообщества",
+    votesTemplate: "{count} голосов · рейтинг сообщества",
+    readingProgress: "Прогресс чтения",
+    related: "Если вам понравилось",
+    minRead: "мин чтения",
+    by: "автор",
+    posted: "Опубликовано",
+  },
+  footer: {
+    aboutHeading: "KRIPIPASTA",
+    about:
+      "Архив интернет-хоррора, поддерживаемый сообществом, — истории, сущности и фольклор, который сеть придумывает о самой себе.",
+    exploreHeading: "Разделы",
+    explore: {
+      all: "Все истории",
+      categories: "Категории",
+      trending: "Популярное",
+      index: "Указатель",
+    },
+    communityHeading: "Сообщество",
+    community: {
+      contribute: "Предложить историю",
+      guidelines: "Правила редактуры",
+      recent: "Последние правки",
+    },
+    estLeft: "ОСН. MMV · РЕДАКТИРУЕТСЯ СООБЩЕСТВОМ",
+    estRight: "ВСЕ ИСТОРИИ — ПЛОДЫ КОЛЛЕКТИВНОГО ВЫМЫСЛА",
+  },
+  notFound: {
+    heading: "Страница потерялась в помехах",
+    body: "Такой истории в архиве нет — возможно, она удалена или ещё не опубликована.",
+    back: "На главную",
+  },
+} as const;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,26 +5,29 @@ export default {
   theme: {
     extend: {
       colors: {
-        surface: {
-          DEFAULT: "#141418",
-          raised: "#17171d",
-          card: "#1c1c24",
-          muted: "#191920",
-          deep: "#151519",
-        },
-        accent: {
+        bg: "#0E0E10",
+        s1: "#141418",
+        s2: "#1A1A20",
+        s3: "#212129",
+        line: "rgba(255,255,255,0.09)",
+        line2: "rgba(255,255,255,0.16)",
+        ink: "#ECECEF",
+        tx2: "rgba(236,236,239,0.66)",
+        tx3: "rgba(236,236,239,0.42)",
+        crimson: {
           DEFAULT: "#B85450",
-          bright: "#CA6E6A",
-          soft: "#E29A96",
-          dim: "#A85C57",
+          2: "#CA6E6A",
           deep: "#6E2C2A",
         },
-        ink: "#ECECEF",
       },
       fontFamily: {
         serif: ["var(--font-serif)", "Georgia", "serif"],
         sans: ["var(--font-sans)", "system-ui", "sans-serif"],
         mono: ["var(--font-mono)", "ui-monospace", "monospace"],
+      },
+      maxWidth: {
+        shell: "1320px",
+        prose: "64ch",
       },
     },
   },


### PR DESCRIPTION
Implements **Plan 3 of 8** — the public, read-only story experience: a themed home/index feed of approved stories and a single-story reading page, rendered from Postgres via Prisma against the `/design` mockups.

## What's included
- **Design tokens & fonts** — mockup palette wired into Tailwind v4 + `globals.css`; Bodoni Moda + Space Grotesk via `next/font/google`.
- **Data-access layer** (`src/lib/stories.ts`) — approved-only queries (feed, featured, by-slug, related, slugs, filter tags).
- **Pure display helpers** (`src/lib/story-display.ts`) — `stripHtml`, `excerpt`, `readingTimeMinutes`, `formatStoryDate`, `ratingLabel`, unit-tested (11 tests).
- **Chrome** — `SiteHeader`, `SiteFooter`, centralized Russian copy (`src/lib/ui-copy.ts`).
- **Components** — `ScoreBadge` (Wilson score ×10), `StoryCard`, URL-driven `StoryFeed` (filter/sort/load-more, no client JS), client `ReadingProgress` bar.
- **Pages** — home (featured hero + feed) and `/story/[slug]` (SSG for all 140 approved slugs, `generateMetadata`, ISR), themed 404.

## Notable deviation from the plan
- **Tailwind v4 config loading:** the plan put tokens in `tailwind.config.ts`, but v4 does **not** auto-load a JS config. Added `@config "../../tailwind.config.ts";` to `globals.css` so the token utilities actually compile (verified `.bg-bg`/`.text-ink` present in built CSS). Without this the design would have silently broken.

## Verification
- `lint` (0 errors), `typecheck`, `test` (35 passed), `build` (140 story pages prerendered) all green.
- Smoke-tested served build: featured hero + feed render real data; `?sort`/`?tag`/`?take` work server-side; approved stories 200; nonexistent and **PENDING** slugs correctly 404 with no body leak.

## Follow-up (not blocking)
- **Filter-chip UX:** `getFilterTags` orders by `Tag.frequency` (computed over all 9681 imported stories), but only 140 are approved. The top-3 chips (`hudi`, `hoody`, `blaskyhoody-man`, freq=2) have **zero approved stories**, so clicking them shows an empty grid. Consider restricting `getFilterTags` to tags that have at least one approved story. Left as-is to stay faithful to the plan spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)