### PR TITLE
fix(build): tolerate absent DB during next build

### DIFF
--- a/src/app/[locale]/dossier/[slug]/page.tsx
+++ b/src/app/[locale]/dossier/[slug]/page.tsx
@@ -16,12 +16,16 @@ import {
   getAllPublishedDossierSlugs,
 } from "@/lib/dossiers";
 import { threatLevelKey, dossierScore100 } from "@/lib/dossier-display";
+import { buildSafe } from "@/lib/build-safe";
 
 export const revalidate = 3600;
 export const dynamicParams = true;
 
 export async function generateStaticParams() {
-  const slugs = await getAllPublishedDossierSlugs();
+  const slugs = await buildSafe<string[]>(
+    () => getAllPublishedDossierSlugs(),
+    [],
+  );
   return routing.locales.flatMap((locale) =>
     slugs.map((slug) => ({ locale, slug })),
   );

--- a/src/app/[locale]/dossier/page.tsx
+++ b/src/app/[locale]/dossier/page.tsx
@@ -4,6 +4,7 @@ import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import DossierCard from "@/components/DossierCard";
 import { getPublishedDossiers } from "@/lib/dossiers";
+import { buildSafe } from "@/lib/build-safe";
 
 export const revalidate = 3600;
 
@@ -25,7 +26,7 @@ export default async function DossierIndexPage({
   const { locale } = await params;
   setRequestLocale(locale);
   const t = await getTranslations("dossier");
-  const dossiers = await getPublishedDossiers();
+  const dossiers = await buildSafe(() => getPublishedDossiers(), []);
 
   return (
     <>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -7,6 +7,7 @@ import ScoreBadge from "@/components/ScoreBadge";
 import { getFeaturedStory, type StorySort } from "@/lib/stories";
 import { excerpt, ratingKey } from "@/lib/story-display";
 import { storyScore10 } from "@/lib/scoring/display";
+import { buildSafe } from "@/lib/build-safe";
 
 export const revalidate = 3600;
 
@@ -35,7 +36,7 @@ export default async function HomePage({
   const sort = parseSort(sp.sort);
   const take = parseTake(sp.take);
   const tagSlug = sp.tag || undefined;
-  const featured = await getFeaturedStory();
+  const featured = await buildSafe(() => getFeaturedStory(), null);
 
   return (
     <>

--- a/src/app/[locale]/story/[slug]/page.tsx
+++ b/src/app/[locale]/story/[slug]/page.tsx
@@ -18,12 +18,13 @@ import {
   readingTimeMinutes,
   excerpt,
 } from "@/lib/story-display";
+import { buildSafe } from "@/lib/build-safe";
 
 export const revalidate = 3600;
 export const dynamicParams = true;
 
 export async function generateStaticParams() {
-  const slugs = await getAllApprovedSlugs();
+  const slugs = await buildSafe<string[]>(() => getAllApprovedSlugs(), []);
   return routing.locales.flatMap((locale) =>
     slugs.map((slug) => ({ locale, slug })),
   );

--- a/src/components/StoryFeed.tsx
+++ b/src/components/StoryFeed.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/stories";
 import StoryCard from "@/components/StoryCard";
 import { getTranslations } from "next-intl/server";
+import { buildSafe } from "@/lib/build-safe";
 
 const PAGE = 9;
 
@@ -29,8 +30,11 @@ export default async function StoryFeed({
 }) {
   const t = await getTranslations("feed");
   const [{ items, total }, tags] = await Promise.all([
-    getApprovedStories({ sort, tagSlug, take }),
-    getFilterTags(7),
+    buildSafe(() => getApprovedStories({ sort, tagSlug, take }), {
+      items: [],
+      total: 0,
+    }),
+    buildSafe(() => getFilterTags(7), []),
   ]);
 
   const sorts: { key: StorySort; label: string }[] = [

--- a/src/lib/build-safe.ts
+++ b/src/lib/build-safe.ts
@@ -1,0 +1,23 @@
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
+
+/**
+ * Run a DB-backed read that also executes during `next build`.
+ *
+ * The production image is compiled by the remote Kamal builder with NO database
+ * reachable, so any Prisma query at build time throws. These pages are ISR
+ * (`revalidate`), so their content is hydrated at runtime against the real DB;
+ * at build we only need an empty shell. Swallow the error and return `fallback`
+ * during the build phase, but rethrow at runtime so a genuine DB outage still
+ * surfaces (500) instead of silently rendering empty.
+ */
+export async function buildSafe<T>(
+  query: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  try {
+    return await query();
+  } catch (err) {
+    if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) return fallback;
+    throw err;
+  }
+}


### PR DESCRIPTION
## Problem

The first `kamal build push` failed at `next build`: the remote builder has no database, so build-time Prisma reads threw (`Prisma validation error at schema.prisma:7` → `Failed to collect page data for /[locale]/story/[slug]`). This passed in CI only because CI runs a live Postgres service.

## Fix

Add `src/lib/build-safe.ts` — `buildSafe(query, fallback)` returns `fallback` when a read throws **during the build phase** (`NEXT_PHASE === phase-production-build`) and rethrows at runtime, so genuine DB outages still surface as 500s.

Applied to the five build-time reads (all ISR pages/components):
- `story/[slug]` + `dossier/[slug]` `generateStaticParams` → `[]`
- home `getFeaturedStory()` → `null`; `StoryFeed` (`getApprovedStories` + `getFilterTags`) → empty
- dossier index `getPublishedDossiers()` → `[]`

Content hydrates via ISR against the live DB on first request (the shared Postgres is reachable at runtime via the kamal-net `postgres` alias).

## Verification
- ✅ typecheck / lint / 100 tests pass
- Real validator is the DB-less `kamal build` (CI's build has a DB and won't exercise the fallback path) — run post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)