### PR TITLE
fix(deploy): prisma CLI full dep closure for migrate-on-start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,20 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 
-# Prisma schema/migrations + CLI + engines so migrations self-apply at startup.
+# Prisma schema + migrations for `migrate deploy`.
 COPY --from=builder /app/prisma ./prisma
-COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
+# Runtime Prisma client + query engine (belt-and-suspenders over standalone tracing).
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+
+# Prisma CLI with its FULL dependency closure (incl. the hoisted `effect` dep of
+# @prisma/config), installed into an isolated prefix so `migrate deploy` runs at
+# startup and npm can't prune the slim standalone node_modules. Keep the version
+# in sync with package.json's prisma devDependency.
+RUN mkdir -p /opt/prisma-cli \
+  && cd /opt/prisma-cli \
+  && npm init -y >/dev/null 2>&1 \
+  && npm install prisma@6.19.3 >/dev/null 2>&1
 
 COPY docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "→ Applying database migrations (prisma migrate deploy)…"
-node node_modules/prisma/build/index.js migrate deploy
+node /opt/prisma-cli/node_modules/prisma/build/index.js migrate deploy --schema /app/prisma/schema.prisma
 
 echo "→ Starting Next.js server…"
 exec node server.js


### PR DESCRIPTION
Second deploy blocker (after #88): `prisma migrate deploy` at container start crashed with `Cannot find module 'effect'` — the piecemeal `node_modules` copy (`prisma`/`@prisma`/`.prisma`) omitted hoisted transitive deps of `@prisma/config`.

Fix: install the Prisma CLI with its complete dependency tree into an isolated `/opt/prisma-cli` prefix (so npm can't prune the slim standalone `node_modules`), and point the entrypoint at it. Runtime `@prisma/client` + engine copies are unchanged.

Deployed to axveer and verified live: valid LE cert, `/ru`+`/en` 200, `/api/health` 200, www→apex 308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)