### PR TITLE
chore: rename Nocturne to Kripipasta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-DATABASE_URL="postgresql://nocturne:nocturne@localhost:5432/nocturne?schema=public&connection_limit=5"
+DATABASE_URL="postgresql://kripipasta:kripipasta@localhost:5432/kripipasta?schema=public&connection_limit=5"
 ADMIN_PASSWORD="change-me"
 ADMIN_SESSION_SECRET="generate-a-long-random-hex-string"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,18 @@ jobs:
       postgres:
         image: postgres:16
         env:
-          POSTGRES_USER: nocturne
-          POSTGRES_PASSWORD: nocturne
-          POSTGRES_DB: nocturne
+          POSTGRES_USER: kripipasta
+          POSTGRES_PASSWORD: kripipasta
+          POSTGRES_DB: kripipasta
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U nocturne"
+          --health-cmd "pg_isready -U kripipasta"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql://nocturne:nocturne@localhost:5432/nocturne?schema=public&connection_limit=5
+      DATABASE_URL: postgresql://kripipasta:kripipasta@localhost:5432/kripipasta?schema=public&connection_limit=5
       ADMIN_PASSWORD: ci-password
       ADMIN_SESSION_SECRET: ci-session-secret-0123456789abcdef0123456789abcdef
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,13 @@ services:
     image: postgres:16
     restart: unless-stopped
     environment:
-      POSTGRES_USER: nocturne
-      POSTGRES_PASSWORD: nocturne
-      POSTGRES_DB: nocturne
+      POSTGRES_USER: kripipasta
+      POSTGRES_PASSWORD: kripipasta
+      POSTGRES_DB: kripipasta
     ports:
       - "5432:5432"
     volumes:
-      - nocturne_pgdata:/var/lib/postgresql/data
+      - kripipasta_pgdata:/var/lib/postgresql/data
 
 volumes:
-  nocturne_pgdata:
+  kripipasta_pgdata:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kripipasta.com",
   "version": "0.3.0",
-  "description": "Nocturne — internet horror archive.",
+  "description": "Kripipasta — internet horror archive.",
   "author": "Vladimir Babin",
   "license": "MIT",
   "type": "module",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -26,7 +26,7 @@ export function generateStaticParams() {
 }
 
 export const metadata: Metadata = {
-  title: "Nocturne — Архив интернет-хоррора",
+  title: "Kripipasta — Архив интернет-хоррора",
   description:
     "Архив интернет-хоррора: истории, сущности и городские легенды сети.",
 };


### PR DESCRIPTION
Replaces the leftover **Nocturne** project name with **Kripipasta** throughout.

## Changes
- **Branding**: root layout `<title>` (`Kripipasta — Архив интернет-хоррора`) and `package.json` description.
- **Local/CI Postgres identifiers**: `nocturne` user/password/db → `kripipasta`, and compose volume `nocturne_pgdata` → `kripipasta_pgdata`. This aligns local/CI with production, which already uses the `kripipasta` role/db.

Story and dossier pages already branded as "Kripipasta"; this cleans up the generic pages (home, 404) and internal dev/CI naming.

## Verification
- `typecheck` clean, **100/100 tests pass**
- Local Postgres recreated under `kripipasta` creds, re-seeded (9,681 stories / 218,095 votes / 2 dossiers), `db:migrate:verify` OK
- Zero `nocturne` references remain in the tree

## Notes
- **Prod DB unaffected** — production already uses the `kripipasta` role/db.
- The title change reaches prod on redeploy (baked into the build).