### PR TITLE
feat(search): Postgres full-text search over stories and dossiers

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -23,6 +23,17 @@
     "empty": "No published stories yet."
   },
   "hero": { "featured": "Story of the week", "read": "Read the story →" },
+  "search": {
+    "eyebrow": "Search",
+    "promptHeading": "Search the archive",
+    "prompt": "Enter a query to find stories and dossiers.",
+    "resultsHeading": "Results",
+    "resultsFor": "for “{query}”",
+    "countTemplate": "{total} found",
+    "empty": "Nothing found for “{query}”.",
+    "storiesHeading": "Stories",
+    "dossiersHeading": "Dossiers"
+  },
   "story": {
     "backToArchive": "‹ Back to the archive",
     "ratingLabel": "Community rating",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -23,6 +23,17 @@
     "empty": "Пока нет опубликованных историй."
   },
   "hero": { "featured": "История недели", "read": "Читать историю →" },
+  "search": {
+    "eyebrow": "Поиск",
+    "promptHeading": "Поиск по архиву",
+    "prompt": "Введите запрос, чтобы найти истории и досье.",
+    "resultsHeading": "Результаты",
+    "resultsFor": "по запросу «{query}»",
+    "countTemplate": "Найдено: {total}",
+    "empty": "Ничего не найдено по запросу «{query}».",
+    "storiesHeading": "Истории",
+    "dossiersHeading": "Досье"
+  },
   "story": {
     "backToArchive": "‹ Назад в архив",
     "ratingLabel": "Рейтинг сообщества",

--- a/prisma/migrations/20260724092516_add_search_vectors/migration.sql
+++ b/prisma/migrations/20260724092516_add_search_vectors/migration.sql
@@ -1,0 +1,35 @@
+-- Full-text search vectors as STORED generated columns.
+-- Config 'russian' stems Cyrillic and still tokenizes Latin words; the text-search
+-- parser classifies HTML tags as a separate token type that the config ignores,
+-- so indexing contentHtml directly skips markup and indexes only visible words.
+
+-- array_to_string is only STABLE, which a generated column rejects. Wrap it in an
+-- IMMUTABLE SQL function (deterministic for text[]) so aliases can be indexed.
+CREATE OR REPLACE FUNCTION kripipasta_array_text(text[])
+  RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$ SELECT array_to_string($1, ' ') $$;
+
+-- Story: title (A) > intro (B) > body (C)
+ALTER TABLE "Story" ADD COLUMN "searchVector" tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('russian', coalesce("title", '')), 'A') ||
+    setweight(to_tsvector('russian', coalesce("intro", '')), 'B') ||
+    setweight(to_tsvector('russian', coalesce("contentHtml", '')), 'C')
+  ) STORED;
+
+-- Dossier: name + aliases (A) > epithet + category (B) > lead + origin (C)
+ALTER TABLE "Dossier" ADD COLUMN "searchVector" tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('russian', coalesce("name", '')), 'A') ||
+    setweight(to_tsvector('russian', kripipasta_array_text("aliases")), 'A') ||
+    setweight(to_tsvector('russian', coalesce("epithet", '')), 'B') ||
+    setweight(to_tsvector('russian', coalesce("category", '')), 'B') ||
+    setweight(to_tsvector('russian', coalesce("lead", '')), 'C') ||
+    setweight(to_tsvector('russian', coalesce("origin", '')), 'C')
+  ) STORED;
+
+-- CreateIndex
+CREATE INDEX "Story_searchVector_idx" ON "Story" USING GIN ("searchVector");
+
+-- CreateIndex
+CREATE INDEX "Dossier_searchVector_idx" ON "Dossier" USING GIN ("searchVector");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,8 +50,13 @@ model Story {
   updatedAt    DateTime      @updatedAt
   tags         StoryTag[]
 
+  // Full-text search vector. Populated by a STORED generated column defined in
+  // the migration (title=A, intro=B, contentHtml=C). Queried via $queryRaw only.
+  searchVector Unsupported("tsvector")?
+
   @@index([status, score])
   @@index([status, createdAt])
+  @@index([searchVector], type: Gin)
 }
 
 model Tag {
@@ -106,7 +111,12 @@ model Dossier {
   gallery       DossierImage[]
   popularity    PopularityPoint[]
 
+  // Full-text search vector. Populated by a STORED generated column defined in
+  // the migration (name/aliases=A, epithet/category=B, lead/origin=C).
+  searchVector Unsupported("tsvector")?
+
   @@index([status, score])
+  @@index([searchVector], type: Gin)
 }
 
 model DossierSection {

--- a/src/app/[locale]/search/page.tsx
+++ b/src/app/[locale]/search/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import SiteHeader from "@/components/SiteHeader";
+import SiteFooter from "@/components/SiteFooter";
+import StoryCard from "@/components/StoryCard";
+import DossierCard from "@/components/DossierCard";
+import { search } from "@/lib/search";
+import { buildSafe } from "@/lib/build-safe";
+
+// Results depend on the ?q= query param, so this page must render per-request.
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "search" });
+  return { title: `${t("eyebrow")} — Kripipasta` };
+}
+
+export default async function SearchPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{ q?: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations("search");
+
+  const { q } = await searchParams;
+  const results = await buildSafe(() => search(q), null);
+
+  return (
+    <>
+      <SiteHeader />
+      <main className="pt-16">
+        <div className="mx-auto max-w-shell px-6 py-12 md:px-10">
+          <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-crimson-2">
+            {t("eyebrow")}
+          </p>
+
+          {!results ? (
+            <>
+              <h1 className="mt-2 font-serif text-[clamp(30px,5vw,60px)] font-medium text-ink">
+                {t("promptHeading")}
+              </h1>
+              <p className="mt-3 max-w-prose text-tx2">{t("prompt")}</p>
+            </>
+          ) : (
+            <>
+              <h1 className="mt-2 font-serif text-[clamp(30px,5vw,60px)] font-medium text-ink">
+                {t("resultsHeading")}{" "}
+                <span className="text-tx2">
+                  {t("resultsFor", { query: results.query })}
+                </span>
+              </h1>
+              <p className="mt-3 font-mono text-[11px] text-tx3">
+                {t("countTemplate", { total: results.total })}
+              </p>
+
+              {results.total === 0 ? (
+                <p className="mt-12 text-tx2">
+                  {t("empty", { query: results.query })}
+                </p>
+              ) : (
+                <div className="mt-10 space-y-14">
+                  {results.stories.length > 0 && (
+                    <section>
+                      <h2 className="font-mono text-[12px] uppercase tracking-[0.2em] text-tx3">
+                        {t("storiesHeading")}
+                      </h2>
+                      <div className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                        {results.stories.map((story) => (
+                          <StoryCard key={story.id} story={story} />
+                        ))}
+                      </div>
+                    </section>
+                  )}
+
+                  {results.dossiers.length > 0 && (
+                    <section>
+                      <h2 className="font-mono text-[12px] uppercase tracking-[0.2em] text-tx3">
+                        {t("dossiersHeading")}
+                      </h2>
+                      <div className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                        {results.dossiers.map((d) => (
+                          <DossierCard key={d.id} dossier={d} />
+                        ))}
+                      </div>
+                    </section>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+
+export default function SearchBox({ initialQuery = "" }: { initialQuery?: string }) {
+  const t = useTranslations("header");
+  const router = useRouter();
+  const [value, setValue] = useState(initialQuery);
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const q = value.trim();
+        if (!q) return;
+        router.push(`/search?q=${encodeURIComponent(q)}`);
+      }}
+      role="search"
+      className="flex w-full items-center gap-2 rounded-[11px] border border-line bg-s1 px-3 py-[9px] text-tx3 focus-within:border-line2"
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+        <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+        <path d="m20 20-3.5-3.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+      <input
+        type="search"
+        name="q"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={t("searchPlaceholder")}
+        aria-label={t("searchPlaceholder")}
+        className="w-full min-w-0 bg-transparent text-[12px] text-ink placeholder:text-tx3 focus:outline-none"
+      />
+    </form>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,6 +1,7 @@
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import LocaleSwitcher from "@/components/LocaleSwitcher";
+import SearchBox from "@/components/SearchBox";
 
 export default function SiteHeader() {
   const tSite = useTranslations("site");
@@ -31,13 +32,7 @@ export default function SiteHeader() {
         </nav>
 
         <div className="ml-auto hidden min-w-0 flex-1 items-center md:flex md:max-w-[420px]">
-          <div className="flex w-full items-center gap-2 rounded-[11px] border border-line bg-s1 px-3 py-[9px] text-tx3">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
-              <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
-              <path d="m20 20-3.5-3.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            </svg>
-            <span className="truncate text-[12px]">{tHeader("searchPlaceholder")}</span>
-          </div>
+          <SearchBox />
         </div>
 
         <div className="ml-auto flex items-center gap-3 md:ml-0">

--- a/src/lib/dossiers.ts
+++ b/src/lib/dossiers.ts
@@ -149,6 +149,30 @@ export async function getPublishedDossiers(): Promise<DossierListItem[]> {
   return rows;
 }
 
+export async function searchPublishedDossiers(
+  query: string,
+  take = 12,
+): Promise<DossierListItem[]> {
+  // Rank by full-text relevance (GIN-indexed searchVector), tie-break on score.
+  const ranked = await prisma.$queryRaw<{ id: string }[]>`
+    SELECT id
+    FROM "Dossier"
+    WHERE status = 'APPROVED'
+      AND "searchVector" @@ websearch_to_tsquery('russian', ${query})
+    ORDER BY ts_rank("searchVector", websearch_to_tsquery('russian', ${query})) DESC,
+             score DESC
+    LIMIT ${take}
+  `;
+  if (ranked.length === 0) return [];
+  const ids = ranked.map((r) => r.id);
+  const rows: ListRow[] = await prisma.dossier.findMany({
+    where: { id: { in: ids } },
+    select: listSelect,
+  });
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  return ids.map((id) => byId.get(id)).filter((d): d is ListRow => !!d);
+}
+
 export async function getAllPublishedDossierSlugs(): Promise<string[]> {
   const rows = await prisma.dossier.findMany({
     where: { status: "APPROVED" },

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { normalizeQuery } from "./search";
+
+describe("normalizeQuery", () => {
+  it("trims and collapses whitespace", () => {
+    expect(normalizeQuery("  the   rake  ")).toBe("the rake");
+    expect(normalizeQuery("слендер\n\tмен")).toBe("слендер мен");
+  });
+
+  it("returns null for empty or whitespace-only input", () => {
+    expect(normalizeQuery("")).toBeNull();
+    expect(normalizeQuery("   ")).toBeNull();
+    expect(normalizeQuery(undefined)).toBeNull();
+    expect(normalizeQuery(null)).toBeNull();
+  });
+
+  it("caps length at 100 characters", () => {
+    const long = "a".repeat(250);
+    expect(normalizeQuery(long)).toHaveLength(100);
+  });
+
+  it("preserves search operators for websearch_to_tsquery", () => {
+    expect(normalizeQuery('"exact phrase" -exclude or thing')).toBe(
+      '"exact phrase" -exclude or thing',
+    );
+  });
+});

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,37 @@
+import { searchApprovedStories, type StoryListItem } from "@/lib/stories";
+import {
+  searchPublishedDossiers,
+  type DossierListItem,
+} from "@/lib/dossiers";
+
+const MAX_QUERY_LENGTH = 100;
+
+/**
+ * Normalize a raw user query for full-text search. Trims, collapses internal
+ * whitespace, and caps length. Returns null when nothing searchable remains.
+ * Operator characters are left intact — websearch_to_tsquery parses them safely.
+ */
+export function normalizeQuery(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  const cleaned = raw.replace(/\s+/g, " ").trim().slice(0, MAX_QUERY_LENGTH);
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+export interface SearchResults {
+  query: string;
+  stories: StoryListItem[];
+  dossiers: DossierListItem[];
+  total: number;
+}
+
+export async function search(
+  raw: string | undefined | null,
+): Promise<SearchResults | null> {
+  const query = normalizeQuery(raw);
+  if (!query) return null;
+  const [stories, dossiers] = await Promise.all([
+    searchApprovedStories(query),
+    searchPublishedDossiers(query),
+  ]);
+  return { query, stories, dossiers, total: stories.length + dossiers.length };
+}

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -129,6 +129,30 @@ export async function getRelatedStories(
   return rows.map(toListItem);
 }
 
+export async function searchApprovedStories(
+  query: string,
+  take = 12,
+): Promise<StoryListItem[]> {
+  // Rank by full-text relevance (GIN-indexed searchVector), tie-break on score.
+  const ranked = await prisma.$queryRaw<{ id: string }[]>`
+    SELECT id
+    FROM "Story"
+    WHERE status = 'APPROVED'
+      AND "searchVector" @@ websearch_to_tsquery('russian', ${query})
+    ORDER BY ts_rank("searchVector", websearch_to_tsquery('russian', ${query})) DESC,
+             score DESC
+    LIMIT ${take}
+  `;
+  if (ranked.length === 0) return [];
+  const ids = ranked.map((r) => r.id);
+  const rows = await prisma.story.findMany({
+    where: { id: { in: ids } },
+    select: listSelect,
+  });
+  const byId = new Map(rows.map((r) => [r.id, toListItem(r)]));
+  return ids.map((id) => byId.get(id)).filter((s): s is StoryListItem => !!s);
+}
+
 export async function getAllApprovedSlugs(): Promise<string[]> {
   const rows = await prisma.story.findMany({
     where: { status: "APPROVED" },


### PR DESCRIPTION
## Summary
Implements site search (spec §9) using **Postgres full-text search** over both content types, exposed via a dedicated `/search` page. The previously non-functional header search box is now wired up.

## What's included
- **Migration** `20260724092516_add_search_vectors`: STORED generated `searchVector tsvector` columns on `Story` (title=A, intro=B, body=C) and `Dossier` (name+aliases=A, epithet+category=B, lead+origin=C), both GIN-indexed. Uses the `'russian'` config — stems Cyrillic, tokenizes Latin, and the text-search parser drops HTML `tag` tokens so `contentHtml` indexes cleanly without stripping markup.
  - **Gotcha handled:** `array_to_string` is only `STABLE`, so a generated column referencing it fails with *"generation expression is not immutable"*. Wrapped in an `IMMUTABLE` SQL helper `kripipasta_array_text()` so aliases can be indexed.
- `src/lib/search.ts` — `normalizeQuery` (trim/collapse/cap-100; safe for `websearch_to_tsquery`) + `search()` orchestrator returning grouped results.
- `searchApprovedStories` / `searchPublishedDossiers` — rank via `ts_rank`, then re-fetch through existing Prisma selects to reuse the feed's card mappers.
- `src/app/[locale]/search/page.tsx` — `force-dynamic`, reads `?q=`, grouped Stories/Dossiers grids with prompt + no-results states.
- `SearchBox` client island replaces the static header box; submits to `/search?q=` via the locale-aware router.
- `search` i18n namespace added for `ru`/`en`.

## Verification
- `typecheck` ✅, `lint` ✅ (only pre-existing config warnings), **104 tests pass** (4 new for `normalizeQuery`).
- Migration applied to a local 9,681-row DB; live-checked across locales: `слендермен`→6 stories, `rake`→1 dossier, gibberish→0. No runtime errors.