### PR TITLE
fix(dossier): render index dynamically instead of stale ISR

### DIFF
--- a/src/app/[locale]/dossier/page.tsx
+++ b/src/app/[locale]/dossier/page.tsx
@@ -6,7 +6,10 @@ import DossierCard from "@/components/DossierCard";
 import { getPublishedDossiers } from "@/lib/dossiers";
 import { buildSafe } from "@/lib/build-safe";
 
-export const revalidate = 3600;
+// Render against the live DB per request. As a static/ISR route this page has no
+// dynamic params and gets prerendered empty on the DB-less build server, then
+// serves that stale snapshot (seeds/direct DB writes never fire revalidatePath).
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata({
   params,


### PR DESCRIPTION
## Problem
`/[locale]/dossier` renders an empty list in production even though 2 dossiers are seeded and their detail pages return `200`.

**Root cause:** the index is a static route with no dynamic params, so it's prerendered at build time on the DB-less remote builder. `buildSafe()` returns `[]` there, baking an empty grid into the image, which is then served as a cache `HIT` (`x-nextjs-cache: HIT`, `s-maxage=3600, stale-while-revalidate=…`). Dossiers were seeded via the standalone `db:seed:dossiers` script writing straight to the DB, so `revalidatePath('/[locale]/dossier')` (which the admin save action *does* call) never fired — the stale snapshot was never invalidated. Detail pages work because `generateStaticParams` returned `[]` at build, so they fall through to on-demand runtime rendering against the live DB.

## Fix
`export const dynamic = "force-dynamic"` on the dossier index — it now renders against the live DB per request (a small approved-dossiers query), the same way the home page already behaves dynamically via `searchParams`. Immune to the build-bakes-empty problem on every deploy.

## Verification
- Changed file lints clean; `typecheck` ✅; **104 tests pass**.
- (The only local lint noise is stale `.next/` dev artifacts, absent in CI which lints before building.)