### PR TITLE
fix: polish batch — filter chips, locale dates, themed 404

### DIFF
--- a/src/app/[locale]/[...rest]/page.tsx
+++ b/src/app/[locale]/[...rest]/page.tsx
@@ -1,0 +1,10 @@
+import { notFound } from "next/navigation";
+
+// Catch-all for unknown paths under a locale (e.g. /ru/does-not-exist). Without
+// this, unmatched routes fall through to Next's root-level default 404, which
+// renders unstyled because the root layout has no NextIntlClientProvider. Calling
+// notFound() here routes them to the themed [locale]/not-found.tsx instead.
+// More specific routes (/story/[slug], /dossier/[slug], /submit, …) still win.
+export default function CatchAllPage() {
+  notFound();
+}

--- a/src/app/[locale]/admin/dossiers/page.tsx
+++ b/src/app/[locale]/admin/dossiers/page.tsx
@@ -51,7 +51,7 @@ export default async function AdminDossiersPage({
                   {d.name}
                 </Link>
                 <p className="mt-1 font-mono text-[11px] text-tx3">
-                  {d.status === "APPROVED" ? t("statusApproved") : t("statusDraft")} · {formatStoryDate(d.updatedAt)}
+                  {d.status === "APPROVED" ? t("statusApproved") : t("statusDraft")} · {formatStoryDate(d.updatedAt, locale)}
                 </p>
               </div>
               <div className="flex shrink-0 items-center gap-2">

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -97,7 +97,7 @@ export default async function AdminQueuePage({
                   {s.title}
                 </Link>
                 <p className="mt-1 font-mono text-[11px] text-tx3">
-                  {t("submittedOn")} {formatStoryDate(s.createdAt)}
+                  {t("submittedOn")} {formatStoryDate(s.createdAt, locale)}
                   {s.authorName && ` · ${t("submittedBy")}: ${s.authorName}`}
                   {s.legacyId !== null && " · legacy"}
                 </p>

--- a/src/app/[locale]/admin/story/[id]/page.tsx
+++ b/src/app/[locale]/admin/story/[id]/page.tsx
@@ -35,7 +35,7 @@ export default async function AdminStoryPage({
         {story.title}
       </h1>
       <p className="mt-3 font-mono text-[11px] text-tx3">
-        {t("submittedOn")} {formatStoryDate(story.createdAt)}
+        {t("submittedOn")} {formatStoryDate(story.createdAt, locale)}
         {story.authorName && ` · ${t("submittedBy")}: ${story.authorName}`}
         {story.authorEmail && ` · ${story.authorEmail}`}
       </p>

--- a/src/app/[locale]/story/[slug]/page.tsx
+++ b/src/app/[locale]/story/[slug]/page.tsx
@@ -75,7 +75,7 @@ export default async function StoryPage({
 
   const related = await getRelatedStories(story, 3);
   const minutes = readingTimeMinutes(story.contentHtml);
-  const posted = formatStoryDate(story.approvedAt ?? story.createdAt);
+  const posted = formatStoryDate(story.approvedAt ?? story.createdAt, locale);
 
   const canonical = `${SITE_URL}/${locale}/story/${slug}`;
   const articleLd = {

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -165,6 +165,10 @@ export async function getFilterTags(
   take = 8,
 ): Promise<{ slug: string; name: string }[]> {
   return prisma.tag.findMany({
+    // `frequency` counts all 9,681 legacy stories, but only APPROVED stories are
+    // browsable — so the top-frequency tags often have zero approved stories and
+    // their chips lead to an empty grid. Restrict to tags with ≥1 approved story.
+    where: { stories: { some: { story: { status: "APPROVED" } } } },
     orderBy: { frequency: "desc" },
     take,
     select: { slug: true, name: true },


### PR DESCRIPTION
Closes the three known minor follow-ups tracked in the project backlog.

## Changes
- **`getFilterTags` empty chips** — restrict to tags with ≥1 `APPROVED` story. `Tag.frequency` counts all 9,681 legacy stories, so the top-frequency chips (`hudi`/`hoody`/`blaskyhoody-man`, freq=2) had **0 approved stories** and led to an empty grid on click. DB-verified: those chips are now excluded.
- **`formatStoryDate` hardcoded `ru-RU`** — thread the active locale through all 4 call sites (story detail + 3 admin pages) so EN users get English date formatting.
- **Locale catch-all 404** — add `src/app/[locale]/[...rest]/page.tsx` (documented next-intl pattern) so unknown locale-prefixed paths (e.g. `/ru/does-not-exist`) render the themed not-found page instead of Next's unstyled root default 404.

## Verification
- typecheck ✓, lint ✓, 128/128 tests ✓, production build ✓ (catch-all registered as dynamic, no route collisions)
- Live-smoke against local DB: unknown path → themed 404 with correct `<title>`; existing routes still 200
- DB query comparison confirmed the old top-frequency chips had 0 approved stories