### PR TITLE
fix: relative Location for /story/{id} 301

### DIFF
--- a/src/app/story/[id]/route.test.ts
+++ b/src/app/story/[id]/route.test.ts
@@ -27,9 +27,9 @@ describe("GET /story/[id]", () => {
     const res = await get("/story/1-smile-dog.html");
 
     expect(res.status).toBe(301);
-    expect(res.headers.get("location")).toBe(
-      "https://kripipasta.com/ru/story/smile-dog",
-    );
+    // Relative Location — resolves against the public host, not the container's
+    // internal 0.0.0.0:3000 bind address.
+    expect(res.headers.get("location")).toBe("/ru/story/smile-dog");
     expect(res.headers.get("cache-control")).toContain("max-age=3600");
     expect(findUnique).toHaveBeenCalledWith({
       where: { legacyId: 1 },

--- a/src/app/story/[id]/route.ts
+++ b/src/app/story/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { type NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
 import { parseLegacyStoryId } from "@/lib/legacy-redirect";
 import { goneResponse } from "@/lib/legacy-gone";
@@ -19,10 +19,16 @@ export async function GET(req: NextRequest) {
   });
 
   if (story?.status === "APPROVED") {
-    return NextResponse.redirect(new URL(`/ru/story/${story.slug}`, req.url), {
+    // Relative Location (path-only): the container binds 0.0.0.0:3000, so
+    // resolving against req.url would leak that internal host into the redirect.
+    // A relative reference is valid per RFC 7231 and resolves to the public host.
+    return new Response(null, {
       status: 301,
-      // Redirects are cheap to cache; keep crawler load off the DB.
-      headers: { "Cache-Control": "public, max-age=3600" },
+      headers: {
+        Location: `/ru/story/${story.slug}`,
+        // Redirects are cheap to cache; keep crawler load off the DB.
+        "Cache-Control": "public, max-age=3600",
+      },
     });
   }
 


### PR DESCRIPTION
Follow-up to #101, caught during prod smoke-test.

**Bug:** `/story/1-smile-dog.html` returned `301` with `Location: https://0.0.0.0:3000/ru/story/smile-dog` — the container's internal bind address (`HOSTNAME=0.0.0.0`, `PORT=3000`) leaked in because `NextResponse.redirect(new URL(slug, req.url))` resolves against `req.url`, which is the internal address behind kamal-proxy.

**Fix:** emit a path-only relative `Location` (`/ru/story/{slug}`) — valid per RFC 7231, resolves against the public host, and matches how the static `/go.php`/section redirects already behave.

Gates: typecheck / lint / test (141) / build all green.